### PR TITLE
Fix string concatenation and lint fix descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.idea
+.gradle
+app/build
+build
+checks/build
+checks/lint-report.html
+local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,9 @@
  */
 buildscript {
     ext {
-        kotlinVersion = '1.8.20'
-        gradlePluginVersion = '8.0.2'
-        lintVersion = '31.0.2'
+        kotlinVersion = '1.9.20'
+        gradlePluginVersion = '8.5.1'
+        lintVersion = '31.5.1'
     }
 
     repositories {

--- a/checks/build.gradle
+++ b/checks/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compileOnly "com.android.tools.lint:lint-api:$lintVersion"
     // You typically don't need this one:
     compileOnly "com.android.tools.lint:lint-checks:$lintVersion"
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.android.tools.lint:lint:$lintVersion"

--- a/checks/src/main/java/com/example/lint/checks/BadCryptographyUsageDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/BadCryptographyUsageDetector.kt
@@ -142,7 +142,7 @@ class BadCryptographyUsageDetector: Detector(), SourceCodeScanner {
                 briefDescription = "Application uses vulnerable cryptography algorithms",
                 explanation =
                 """
-                    Using weak or broken cryptographic hash functions may allow an attacker to reasonably determine
+                    Using weak or broken cryptographic hash functions may allow an attacker to reasonably determine \
                     the original input or produce multiple inputs with the same hash value.
                     """,
                 category = Category.SECURITY,
@@ -159,7 +159,7 @@ class BadCryptographyUsageDetector: Detector(), SourceCodeScanner {
                 briefDescription = "Application uses unsafe cipher modes or paddings with cryptographic algorithms",
                 explanation =
                     """
-                        Using unsafe cipher modes or paddings with safe cryptographic algorithms is insecure, and 
+                        Using unsafe cipher modes or paddings with safe cryptographic algorithms is insecure, and \
                         makes the code vulnerable to issues like padding oracle attacks.
                     """,
                 category = Category.SECURITY,

--- a/checks/src/main/java/com/example/lint/checks/CustomSchemeDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/CustomSchemeDetector.kt
@@ -17,7 +17,6 @@ package com.example.lint.checks
 
 import com.android.SdkConstants.ANDROID_URI
 import com.android.SdkConstants.ATTR_AUTO_VERIFY
-import com.android.SdkConstants.ATTR_SCHEME
 import com.android.SdkConstants.TAG_DATA
 import com.android.SdkConstants.TAG_INTENT_FILTER
 import com.android.tools.lint.detector.api.Category
@@ -79,7 +78,7 @@ class CustomSchemeDetector : Detector(), XmlScanner {
         private val REGULAR_SCHEMES = listOf("http", "https", "file", "ftp", "ftps")
 
         private const val EXPLANATION = """
-        Intent filters should contain the `autoVerify` attribute and explicitly set it to true, in order
+        Intent filters should contain the `autoVerify` attribute and explicitly set it to true, in order \
         to signal to the system to automatically verify the associated hosts in your app's intent filters.
         """
 

--- a/checks/src/main/java/com/example/lint/checks/DnsConfigDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/DnsConfigDetector.kt
@@ -68,7 +68,7 @@ class DnsConfigDetector : Detector(), XmlScanner {
                 // `monospace`, *italic*, and **bold**.
                 explanation =
                 """
-                    Apps targeting SDK versions earlier than 28 are susceptible to DNS attacks like DNS spoofing or 
+                    Apps targeting SDK versions earlier than 28 are susceptible to DNS attacks like DNS spoofing or \
                     cache poisoning
                     """, // no need to .trimIndent(), lint does that automatically
                 category = Category.SECURITY,

--- a/checks/src/main/java/com/example/lint/checks/MisconfiguredFileProviderDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/MisconfiguredFileProviderDetector.kt
@@ -15,7 +15,6 @@
  */
 package com.example.lint.checks
 
-import com.android.SdkConstants
 import com.android.resources.ResourceFolderType
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Implementation
@@ -91,7 +90,7 @@ class MisconfiguredFileProviderDetector: ResourceXmlDetector() {
                 briefDescription = "Application specifies the device root directory ",
                 explanation =
                 """
-                    Allowing the device root directory in the `FileProvider` configuration provides arbitrary access
+                    Allowing the device root directory in the `FileProvider` configuration provides arbitrary access \
                     to files and folders for attackers, thereby increasing the attack surface.
                     """,
                 category = Category.SECURITY,
@@ -108,7 +107,7 @@ class MisconfiguredFileProviderDetector: ResourceXmlDetector() {
                 briefDescription = "Application may expose sensitive info like PII by storing it in external storage",
                 explanation =
                 """
-                    Sensitive information like PII should not be stored outside of the application container or system
+                    Sensitive information like PII should not be stored outside of the application container or system \
                     credential storage facilities
                     """,
                 category = Category.SECURITY,

--- a/checks/src/main/java/com/example/lint/checks/MissingNetworkSecurityConfigDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/MissingNetworkSecurityConfigDetector.kt
@@ -87,7 +87,7 @@ class MissingNetworkSecurityConfigDetector : ResourceXmlDetector(), XmlScanner {
         if (file.exists()) return null
 
         val createConfigFileFix = fix().newFile(file, config).build()
-        return fix().composite(addConfigToManifestFix, createConfigFileFix)
+        return fix().name("Create network security config").composite(addConfigToManifestFix, createConfigFileFix)
     }
 
     companion object {
@@ -126,7 +126,7 @@ class MissingNetworkSecurityConfigDetector : ResourceXmlDetector(), XmlScanner {
                 briefDescription = "Application by default permits cleartext traffic",
                 explanation =
                 """
-            Apps targeting SDK versions earlier than 28 trust cleartext traffic by default. 
+            Apps targeting SDK versions earlier than 28 trust cleartext traffic by default. \
             The application must explicitly opt out of this in order to only use secure connections.
             """,
                 category = Category.SECURITY,
@@ -143,10 +143,10 @@ class MissingNetworkSecurityConfigDetector : ResourceXmlDetector(), XmlScanner {
                 briefDescription = "Application by default trusts user-added CA certificates",
                 explanation =
                 """
-        Apps targeting SDK versions earlier than 24 trust user-added CA certificates by default. 
-        In practice, it is better to limit the set of trusted CAs so only trusted CAs are used for an app's secure 
-        connections.
-        """,
+                Apps targeting SDK versions earlier than 24 trust user-added CA certificates by default. \
+                In practice, it is better to limit the set of trusted CAs so only trusted CAs are used for an app's secure \
+                connections.
+                """,
                 category = Category.SECURITY,
                 priority = 3,
                 severity = Severity.WARNING,

--- a/checks/src/main/java/com/example/lint/checks/PermissionDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/PermissionDetector.kt
@@ -57,9 +57,9 @@ class PermissionDetector : Detector(), XmlScanner {
         private val INSECURE_PROTECTION_LEVELS = setOf("normal")
 
         private const val EXPLANATION = """
-        Custom permissions are designed for sharing resources and capabilities with other apps. However, typos and
-        insufficient protection levels can negate the usage of these custom permissions altogether. In general, use
-        `signature` or higher protection levels whenever possible, as this ensures only other apps signed with the
+        Custom permissions are designed for sharing resources and capabilities with other apps. However, typos and \
+        insufficient protection levels can negate the usage of these custom permissions altogether. In general, use \
+        `signature` or higher protection levels whenever possible, as this ensures only other apps signed with the \
         same certificate can access these protected features.
         """
 

--- a/checks/src/main/java/com/example/lint/checks/SafeBrowsingDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/SafeBrowsingDetector.kt
@@ -58,8 +58,8 @@ class SafeBrowsingDetector : Detector(), XmlScanner {
         private const val ENABLE_SAFE_BROWSING_MANIFEST_VALUE = "android.webkit.WebView.EnableSafeBrowsing"
 
         private const val EXPLANATION = """
-        Safe Browsing is a service to help applications check URLs against a known list of unsafe web 
-        resources. We recommend keeping Safe Browsing enabled at all times and designing your app around 
+        Safe Browsing is a service to help applications check URLs against a known list of unsafe web \
+        resources. We recommend keeping Safe Browsing enabled at all times and designing your app around \
         any constraints this causes.
         """
 

--- a/checks/src/main/java/com/example/lint/checks/StrandhoggDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/StrandhoggDetector.kt
@@ -68,7 +68,7 @@ class StrandhoggDetector : Detector(), XmlScanner {
                 // `monospace`, *italic*, and **bold**.
                 explanation =
                 """
-                    Apps targeting SDK versions earlier than 28 are susceptible to Strandhogg / 
+                    Apps targeting SDK versions earlier than 28 are susceptible to Strandhogg / \
                     Task Affinity attacks.
                     """, // no need to .trimIndent(), lint does that automatically
                 category = Category.SECURITY,

--- a/checks/src/main/java/com/example/lint/checks/TapjackingDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/TapjackingDetector.kt
@@ -59,8 +59,8 @@ class TapjackingDetector : ResourceXmlDetector() {
 
     companion object {
         const val ATTR_FILTER_TOUCHES_OBSCURED = "filterTouchesWhenObscured"
-        val ENABLE_NAME = "enable"
-        val DISABLE_NAME = "disable"
+        const val ENABLE_NAME = "enable"
+        const val DISABLE_NAME = "disable"
 
         @JvmField
         val ISSUE: Issue =
@@ -69,7 +69,7 @@ class TapjackingDetector : ResourceXmlDetector() {
                 briefDescription = "Application's UI is vulnerable to tapjacking attacks",
                 explanation =
                 """
-                    Apps with sensitive UI elements should add the `filterTouchesWithObscured` attribute
+                    Apps with sensitive UI elements should add the `filterTouchesWithObscured` attribute \
                     to protect it from tapjacking / overlay attacks.
                     """,
                 category = Category.SECURITY,

--- a/checks/src/main/java/com/example/lint/checks/UnintendedExposedUrlDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/UnintendedExposedUrlDetector.kt
@@ -73,7 +73,7 @@ class UnintendedExposedUrlDetector: ResourceXmlDetector() {
         if (!IPV4_REGEX.containsMatchIn(value)) return
 
         val ipAddress = IPV4_REGEX.find(value)
-        val isPublicIp = PUBLIC_IP_PREFIXES.mapNotNull {
+        val isPublicIp = PUBLIC_IP_PREFIXES.map {
             ipAddress?.value?.split(".")?.get(0) == it.toString() }.any {it}
 
         val incident =
@@ -127,7 +127,7 @@ class UnintendedExposedUrlDetector: ResourceXmlDetector() {
                 briefDescription = "Application may have a debugging or development URL publicly exposed",
                 explanation =
                 """
-                    URLs that look intended for debugging and development purposes only are exposed in the application,
+                    URLs that look intended for debugging and development purposes only are exposed in the application, \
                     allowing attackers to gain access to parts of the application and server that should be kept secure.
                     """,
                 category = Category.SECURITY,
@@ -144,8 +144,8 @@ class UnintendedExposedUrlDetector: ResourceXmlDetector() {
                 briefDescription = "Application may have a private IP address publicly exposed",
                 explanation =
                 """
-                    Private IP addresses are referenced that may have been intended only for debugging and development.
-                    These should not be exposed publicly, as it may permit attackers to gain unintended access to the
+                    Private IP addresses are referenced that may have been intended only for debugging and development. \
+                    These should not be exposed publicly, as it may permit attackers to gain unintended access to the \
                     application and its resources.
                     """,
                 category = Category.SECURITY,

--- a/checks/src/main/java/com/example/lint/checks/WeakPrngDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/WeakPrngDetector.kt
@@ -16,7 +16,6 @@
 package com.example.lint.checks
 
 import com.android.tools.lint.detector.api.Category
-import com.android.tools.lint.detector.api.ConstantEvaluator
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Incident
@@ -83,8 +82,8 @@ class WeakPrngDetector: Detector(), SourceCodeScanner {
                 briefDescription = "Application uses non-cryptographically secure pseudorandom number generators",
                 explanation =
                 """
-                    If a non-cryptographically secure pseudorandom number generator (PRNG) is used in a security context
-                    like authentication, an attacker may be able to guess the randomly-generated numbers and gain access
+                    If a non-cryptographically secure pseudorandom number generator (PRNG) is used in a security context \
+                    like authentication, an attacker may be able to guess the randomly-generated numbers and gain access \
                     to privileged data or functionality.
                     """,
                 category = Category.SECURITY,

--- a/checks/src/test/java/com/example/lint/checks/BadCryptographyUsageDetectorTest.kt
+++ b/checks/src/test/java/com/example/lint/checks/BadCryptographyUsageDetectorTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.lint.checks;
+package com.example.lint.checks
 
 import com.android.tools.lint.checks.infrastructure.LintDetectorTest
 import com.android.tools.lint.detector.api.Detector
@@ -49,8 +49,8 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                                 Cipher.getInstance(algo);
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expect(
                 """
                 src/fake/pkg/TestBadCryptoDetector.java:8: Error: Using vulnerable cryptographic algorithms puts the original input at risk of discovery [VulnerableCryptoAlgorithm]
@@ -63,7 +63,7 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                 @@ -8 +8
                 -         Cipher.getInstance(algo);
                 +         Cipher.getInstance("AES/GCM/NoPadding");
-            """.trimIndent())
+            """)
 
     }
 
@@ -85,8 +85,8 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                                 Cipher.getInstance(algo + "/" + mode + "/" + padding)
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expect(
                 """
                 src/fake/pkg/TestBadCryptoDetector.kt:10: Error: Using vulnerable cryptographic algorithms puts the original input at risk of discovery [VulnerableCryptoAlgorithm]
@@ -99,7 +99,7 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
             @@ -10 +10
             -         Cipher.getInstance(algo + "/" + mode + "/" + padding)
             +         Cipher.getInstance("AES/GCM/NoPadding")
-            """.trimIndent())
+            """)
 
     }
 
@@ -119,8 +119,8 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                                 Cipher.getInstance(algo);
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expect(
                 """
                 src/fake/pkg/TestBadCryptoDetector.java:8: Error: Using vulnerable cryptographic algorithms puts the original input at risk of discovery [VulnerableCryptoAlgorithm]
@@ -133,7 +133,7 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                 @@ -8 +8
                 -         Cipher.getInstance(algo);
                 +         Cipher.getInstance("ChaCha20");
-            """.trimIndent())
+            """)
 
     }
 
@@ -156,8 +156,8 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                                 Cipher.getInstance(algo + "/" + mode + "/" + padding);
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expect(
                 """
                 src/fake/pkg/TestBadCryptoDetector.java:11: Error: Using vulnerable cryptographic algorithms puts the original input at risk of discovery [VulnerableCryptoAlgorithm]
@@ -170,7 +170,7 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                 @@ -11 +11
                 -         Cipher.getInstance(algo + "/" + mode + "/" + padding);
                 +         Cipher.getInstance("ChaCha20");
-            """.trimIndent())
+            """)
 
     }
 
@@ -193,8 +193,8 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                                 Cipher.getInstance(algo + "/" + mode + "/" + padding)
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expect(
                 """
                     src/fake/pkg/TestBadCryptoDetector.kt:11: Error: Using insecure modes and paddings with cryptographic algorithms is unsafe and vulnerable to attacks [UnsafeCryptoAlgorithmUsage]
@@ -207,7 +207,7 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
             @@ -11 +11
             -         Cipher.getInstance(algo + "/" + mode + "/" + padding)
             +         Cipher.getInstance("RSA/GCM/NoPadding")
-            """.trimIndent())
+            """)
     }
 
     @Test
@@ -229,8 +229,8 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                                 Cipher.getInstance(algo + "/" + mode + "/" + padding)
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expect(
                 """
                     src/fake/pkg/TestBadCryptoDetector.kt:11: Warning: Using insecure modes and paddings with cryptographic algorithms is unsafe and vulnerable to attacks [UnsafeCryptoAlgorithmUsage]
@@ -243,7 +243,7 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
             @@ -11 +11
             -         Cipher.getInstance(algo + "/" + mode + "/" + padding)
             +         Cipher.getInstance("AES/GCM/NoPadding")
-            """.trimIndent())
+            """)
     }
 
     @Test
@@ -265,8 +265,8 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                                 Cipher.getInstance(algo + "/" + mode + "/" + padding)
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expect(
                 """
                     src/fake/pkg/TestBadCryptoDetector.kt:11: Warning: Using insecure modes and paddings with cryptographic algorithms is unsafe and vulnerable to attacks [UnsafeCryptoAlgorithmUsage]
@@ -279,7 +279,7 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
             @@ -11 +11
             -         Cipher.getInstance(algo + "/" + mode + "/" + padding)
             +         Cipher.getInstance("RSA/CBC/OAEPWithSHA-256AndMGF1Padding")
-            """.trimIndent())
+            """)
     }
 
     @Test
@@ -298,8 +298,8 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                                 Cipher.getInstance(algo);
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expectClean()
     }
 
@@ -319,8 +319,8 @@ class BadCryptographyUsageDetectorTest : LintDetectorTest() {
                                 Cipher.getInstance(algo)
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expectClean()
 
     }

--- a/checks/src/test/java/com/example/lint/checks/MisconfiguredFileProviderDetectorTest.kt
+++ b/checks/src/test/java/com/example/lint/checks/MisconfiguredFileProviderDetectorTest.kt
@@ -50,12 +50,13 @@ class MisconfiguredFileProviderDetectorTest : LintDetectorTest() {
                                            <root-path name="root" path="/"/>
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     0 errors, 1 warnings
-                """.trimIndent()
+                """
             ).expectFixDiffs("""
                 Fix for res/xml/file_paths.xml line 5: Delete:
                 @@ -5 +5
                 -                        <root-path name="root" path="/"/>
-            """.trimIndent())
+            """
+            )
     }
 
     @Test
@@ -77,12 +78,12 @@ class MisconfiguredFileProviderDetectorTest : LintDetectorTest() {
                                            <external-path name="external_path" path="sdcard/"/>
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     0 errors, 1 warnings
-                """.trimIndent()
+                """
             ).expectFixDiffs("""
                 Fix for res/xml/file_paths.xml line 5: Delete:
                 @@ -5 +5
                 -                        <external-path name="external_path" path="sdcard/"/>
-            """.trimIndent())
+            """)
     }
 
     @Test

--- a/checks/src/test/java/com/example/lint/checks/MissingNetworkSecurityConfigDetectorTest.kt
+++ b/checks/src/test/java/com/example/lint/checks/MissingNetworkSecurityConfigDetectorTest.kt
@@ -16,6 +16,7 @@
 package com.example.lint.checks
 
 import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.checks.infrastructure.TestFile
 import com.android.tools.lint.detector.api.Detector
 
 import org.junit.Test
@@ -124,7 +125,7 @@ class MissingNetworkSecurityConfigDetectorTest : LintDetectorTest() {
             emptyXmlFile
         ).run().expectFixDiffs(
             """
-                    Fix for AndroidManifest.xml line 3: Set networkSecurityConfig="@xml/network_security_config":
+                    Fix for AndroidManifest.xml line 3: Create network security config:
                     @@ -7 +7
                     -     <application>
                     +     <application android:networkSecurityConfig="@xml/network_security_config" >
@@ -154,7 +155,7 @@ class MissingNetworkSecurityConfigDetectorTest : LintDetectorTest() {
             emptyXmlFile
         ).run().expectFixDiffs(
             """
-                    Fix for AndroidManifest.xml line 3: Set networkSecurityConfig="@xml/network_security_config":
+                    Fix for AndroidManifest.xml line 3: Create network security config:
                     @@ -7 +7
                     -     <application>
                     +     <application android:networkSecurityConfig="@xml/network_security_config" >
@@ -175,11 +176,11 @@ class MissingNetworkSecurityConfigDetectorTest : LintDetectorTest() {
     companion object {
         // It's necessary to add an empty XML File in order for the unit test to recognize that a resources folder
         // exists
-        val emptyXmlFile = xml(
+        val emptyXmlFile: TestFile = xml(
             "res/xml/strings.xml",
             """
                 <strings></strings>
                 """
-        )
+        ).indented()
     }
 }

--- a/checks/src/test/java/com/example/lint/checks/PermissionDetectorTest.kt
+++ b/checks/src/test/java/com/example/lint/checks/PermissionDetectorTest.kt
@@ -92,10 +92,10 @@ class PermissionDetectorTest : LintDetectorTest() {
             ).indented()
         ).run().expect(
             """
-                    AndroidManifest.xml:2: Warning: Custom permissions should have signature `protectionLevel`s or higher [InsecurePermissionProtectionLevel]
-                    <permission android:name="com.android.example.permission.CUSTOM_PERMISSION" />
-                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                    0 errors, 1 warnings
+            AndroidManifest.xml:2: Warning: Custom permissions should have a signature protectionLevel or higher [InsecurePermissionProtectionLevel]
+            <permission android:name="com.android.example.permission.CUSTOM_PERMISSION" />
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            0 errors, 1 warnings
                     """
         )
     }
@@ -115,11 +115,11 @@ class PermissionDetectorTest : LintDetectorTest() {
             ).indented()
         ).run().expect(
                 """
-                    AndroidManifest.xml:2: Warning: Custom permissions should have signature `protectionLevel`s or higher [InsecurePermissionProtectionLevel]
-                    <permission android:name="com.android.example.permission.CUSTOM_PERMISSION"
-                    ^
-                    0 errors, 1 warnings
-                    """
+                AndroidManifest.xml:2: Warning: Custom permissions should have a signature protectionLevel or higher [InsecurePermissionProtectionLevel]
+                <permission android:name="com.android.example.permission.CUSTOM_PERMISSION"
+                ^
+                0 errors, 1 warnings
+                """
             )
     }
 

--- a/checks/src/test/java/com/example/lint/checks/TapjackingDetectorTest.kt
+++ b/checks/src/test/java/com/example/lint/checks/TapjackingDetectorTest.kt
@@ -39,7 +39,7 @@ class TapjackingDetectorTest : LintDetectorTest() {
                         <Switch android:id='enable_setting'>
                         </Switch>
                     </LinearLayout>
-                    """.trimIndent()
+                    """
             ).indented()
         ).run().expect(
             """
@@ -63,7 +63,7 @@ class TapjackingDetectorTest : LintDetectorTest() {
                         android:id='disable_setting'>
                         </CheckBox>
                     </LinearLayout>
-                    """.trimIndent()
+                    """
             ).indented()
         ).run().expect(
             """
@@ -86,7 +86,7 @@ class TapjackingDetectorTest : LintDetectorTest() {
                         <ToggleButton android:id='enable_setting'>
                         </ToggleButton>
                     </LinearLayout>
-                    """.trimIndent()
+                    """
             ).indented()
         ).run().expectFixDiffs(
             """
@@ -111,7 +111,7 @@ class TapjackingDetectorTest : LintDetectorTest() {
                         <CompoundButton android:id='disable_setting'>
                         </CompoundButton>
                     </LinearLayout>
-                    """.trimIndent()
+                    """
             ).indented()
         ).run().expectFixDiffs(
             """
@@ -136,7 +136,7 @@ class TapjackingDetectorTest : LintDetectorTest() {
                     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android">
                         <Button />
                     </LinearLayout>
-                    """.trimIndent()
+                    """
             ).indented()
         ).run().expectClean()
     }
@@ -152,7 +152,7 @@ class TapjackingDetectorTest : LintDetectorTest() {
                     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android">
                         <ToggleButton></ToggleButton>
                     </LinearLayout>
-                    """.trimIndent()
+                    """
                 ).indented()
             ).run().expectClean()
     }

--- a/checks/src/test/java/com/example/lint/checks/UnintendedExposedUrlDetectorTest.kt
+++ b/checks/src/test/java/com/example/lint/checks/UnintendedExposedUrlDetectorTest.kt
@@ -60,7 +60,7 @@ class UnintendedExposedUrlDetectorTest : LintDetectorTest() {
                                                 <domain>8.0.0.28</domain>
                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~
                     0 errors, 3 warnings
-                """.trimIndent()
+                """
             ).expectFixDiffs("Fix for res/xml/network_security_config.xml line 6: Delete:\n" +
                     "@@ -6 +6\n" +
                     "-                             <domain>http://102.1.0.4/hello</domain>\n" +
@@ -97,7 +97,7 @@ class UnintendedExposedUrlDetectorTest : LintDetectorTest() {
                                             <string name='test3'>8.0.0.28</string>
                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     0 errors, 3 warnings
-                """.trimIndent()
+                """
             ).expectFixDiffs("Fix for res/xml/strings.xml line 3: Delete:\n" +
                     "@@ -3 +3\n" +
                     "-                         <string name='test'>http://102.1.0.4/hello</string>\n" +
@@ -138,7 +138,7 @@ class UnintendedExposedUrlDetectorTest : LintDetectorTest() {
                                                 <domain>debug.io</domain>
                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~
                     0 errors, 3 warnings
-                """.trimIndent()
+                """
             ).expectFixDiffs("Fix for res/xml/network_security_config.xml line 6: Delete:\n" +
                     "@@ -6 +6\n" +
                     "-                             <domain>http://staging-app.com</domain>\n" +
@@ -175,7 +175,7 @@ class UnintendedExposedUrlDetectorTest : LintDetectorTest() {
                                             <string name='test3'>debug.io</string>
                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     0 errors, 3 warnings
-                """.trimIndent()
+                """
             ).expectFixDiffs("Fix for res/xml/strings.xml line 3: Delete:\n" +
                     "@@ -3 +3\n" +
                     "-                         <string name='test'>http://staging-app.com</string>\n" +

--- a/checks/src/test/java/com/example/lint/checks/WeakPrngDetectorTest.kt
+++ b/checks/src/test/java/com/example/lint/checks/WeakPrngDetectorTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.lint.checks;
+package com.example.lint.checks
 
 import com.android.tools.lint.checks.infrastructure.LintDetectorTest
 import com.android.tools.lint.detector.api.Detector
@@ -45,8 +45,8 @@ class WeakPrngDetectorTest : LintDetectorTest() {
                                 int random = Math.random() * 100;
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expect(
                 """
                 src/fake/pkg/TestWeakPrngDetector.java:7: Warning: Math.random relies on a weak PRNG, use java.util.Random for non-security contexts and java.security.SecureRandom for security / authentication purposes [WeakPrng]
@@ -61,7 +61,7 @@ class WeakPrngDetectorTest : LintDetectorTest() {
             @@ -7 +8
             -         int random = Math.random() * 100;
             +         int random = Random().nextDouble() * 100;
-            """.trimIndent())
+            """)
 
     }
 
@@ -81,8 +81,8 @@ class WeakPrngDetectorTest : LintDetectorTest() {
                                 val randomDouble = random.nextDouble()
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expect(
                 """
                     src/fake/pkg/TestWeakPrngDetector.kt:7: Warning: java.util.Random should only be used for non-security contexts as it is not a cryptographically secure PRNG [WeakPrng]
@@ -97,7 +97,7 @@ class WeakPrngDetectorTest : LintDetectorTest() {
             @@ -7 +8
             -         val random = Random()
             +         val random = SecureRandom()
-            """.trimIndent())
+            """)
     }
 
     @Test
@@ -115,8 +115,8 @@ class WeakPrngDetectorTest : LintDetectorTest() {
                                 int randomInt = SecureRandom().nextInt(1000);
                             }
                         }
-                    """.trimIndent()
-                )
+                    """
+                ).indented()
             ).run().expectClean()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=true
 org.gradle.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Jul 14 14:58:49 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
First, this CL sets a quickfix name for composite fixes; this is required with newer versions of lints.

Second, it fixes the explanation text strings such that they use the continuation character (\) when a single paragraph flows into the next line.

Finally, it fixes misc smaller issues -- removing redundant trimIndents() (running ./gradlew :check:lint shows warnings for these), updating to newer versions of lint and Kotlin, fixing some warnings, etc.