### PR TITLE
Improve README.md usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,17 @@ for guidance on writing your own custom lint checks.
 This library uses the Apache license, as is Google's default.
 
 ## How to use this library
-This library has now been added to gMaven (maven.google.com) for easier consumption: 
-[link](https://maven.google.com/web/index.html#com.android.security.lint:lint)
+This library has now been added to [Google's Maven Repository](https://maven.google.com/web/index.html#com.android.security.lint:lint) for easier consumption.
 
-1. Add a dependency to the Maven repository in the app directory's `build.gradle` file:
+1. Add the dependency to the app directory's `build.gradle.kts` file:
 
-```shell
-dependencies {
-  lintChecks 'com.android.security.lint:lint:1.0.0'
-}
-```
+   ```kotlin
+   dependencies {
+     lintChecks("com.android.security.lint:lint:1.0.0")
+   }
+   ```
 
-2.  Add `lintVersion` to the overall project's `build.gradle` file in the `ext` section. See [here](build.gradle) for an example:
-```shell
-ext {
-  ...
-  lintVersion = '31.5.1'
-}
-```
-
-3.  Perform a Gradle sync and then run `./gradlew lint` to see the results. Please file an issue if these instructions do not work for you.
+2. Run the lint task `./gradlew lint` to see the results. Please file an issue if these instructions do not work for you.
 
 ## Lint checks included in this library
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This library is available on ![Google's Maven Repository](https://img.shields.io
    }
    ```
 
-3. Run `./gradlew lint` to see the results. Please file an issue if these instructions do not work for you.
+2. Run `./gradlew lint` to see the results. Please file an issue if these instructions do not work for you.
 
 ## Lint checks included in this library
 

--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ for guidance on writing your own custom lint checks.
 This library uses the Apache license, as is Google's default.
 
 ## How to use this library
-This library is available on [Google's Maven Repository](https://maven.google.com/web/index.html#com.android.security.lint:lint).
+This library is available on ![Google's Maven Repository](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fdl.google.com%2Fandroid%2Fmaven2%2Fcom%2Fandroid%2Fsecurity%2Flint%2Flint%2Fmaven-metadata.xml&label=Google's%20Maven%20Repository&link=https%3A%2F%2Fmaven.google.com%2Fweb%2Findex.html%23com.android.security.lint%3Alint)
 
 1. Add the dependency to the app directory's `build.gradle` file:
 
    ```groovy
    dependencies {
-     lintChecks 'com.android.security.lint:lint:1.0.1'
+     lintChecks 'com.android.security.lint:lint:<version>'
    }
    ```
 
    If using Kotlin instead of Groovy, add the dependency to the app directory's `build.gradle.kts` file:
    ```kotlin
    dependencies {
-      lintChecks("com.android.security.lint:lint:1.0.1")
+      lintChecks("com.android.security.lint:lint:<version>")
    }
    ```
 
-2. Run `./gradlew lint` to see the results. Please file an issue if these instructions do not work for you.
+3. Run `./gradlew lint` to see the results. Please file an issue if these instructions do not work for you.
 
 ## Lint checks included in this library
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library is available on [Google's Maven Repository](https://maven.google.co
 
 1. Add the dependency to the app directory's `build.gradle` file:
 
-   ```shell
+   ```groovy
    dependencies {
      lintChecks 'com.android.security.lint:lint:1.0.1'
    }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ for guidance on writing your own custom lint checks.
 This library uses the Apache license, as is Google's default.
 
 ## How to use this library
-This library has now been added to [Google's Maven Repository](https://maven.google.com/web/index.html#com.android.security.lint:lint) for easier consumption.
+This library is available on [Google's Maven Repository](https://maven.google.com/web/index.html#com.android.security.lint:lint).
 
 1. Add the dependency to the app directory's `build.gradle.kts` file:
 


### PR DESCRIPTION
- Re-phrase introduction, gMaven is probably a codename, not widely used by Android devs. Google's Maven Repository is more explicit.
- Re-phrase 1st step
- Replace code snippet with Kotlin version (most of Android devs are now using Kotlin as their main language for Gradle scripts, but I can revert this if necessary)
- Fix missing indentation of code snippet
- Fix language highlighting of code snippet
- Remove unnecessary `lintVersion` configuration step since we are directly consuming the dependency from maven
- Remove unnecessary mention of Gradle sync.

Would you be open to add a Shields.io badge like this to automatically show the latest version available?

![Google's Maven Repository](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fdl.google.com%2Fandroid%2Fmaven2%2Fcom%2Fandroid%2Fsecurity%2Flint%2Flint%2Fmaven-metadata.xml&label=%20&link=https%3A%2F%2Fmaven.google.com%2Fweb%2Findex.html%23com.android.security.lint%3Alint)

Or maybe you already have this kind of service internally that could be used?
