### PR TITLE
Don't alert for Tapjacking if the attribute is already present

### DIFF
--- a/checks/src/main/java/com/example/lint/checks/TapjackingDetector.kt
+++ b/checks/src/main/java/com/example/lint/checks/TapjackingDetector.kt
@@ -40,6 +40,13 @@ class TapjackingDetector : ResourceXmlDetector() {
     override fun getApplicableElements() = setOf(TOGGLE_BUTTON, COMPOUND_BUTTON, CHECK_BOX, SWITCH)
 
     override fun visitElement(context: XmlContext, element: Element) {
+        if (element.hasAttributeNS(ANDROID_URI, ATTR_FILTER_TOUCHES_OBSCURED)) {
+            val attrValue: String? = element.getAttributeNS(ANDROID_URI, ATTR_FILTER_TOUCHES_OBSCURED)
+            if (attrValue.toBoolean()) {
+                return
+            }
+        }
+
         val name = element.getAttributeNodeNS(ANDROID_URI, ATTR_ID)?.value ?: return
 
         if (ENABLE_NAME in name || DISABLE_NAME in name) {
@@ -69,7 +76,7 @@ class TapjackingDetector : ResourceXmlDetector() {
                 briefDescription = "Application's UI is vulnerable to tapjacking attacks",
                 explanation =
                 """
-                    Apps with sensitive UI elements should add the `filterTouchesWithObscured` attribute \
+                    Apps with sensitive UI elements should add the `filterTouchesWhenObscured` attribute \
                     to protect it from tapjacking / overlay attacks.
                     """,
                 category = Category.SECURITY,

--- a/checks/src/test/java/com/example/lint/checks/TapjackingDetectorTest.kt
+++ b/checks/src/test/java/com/example/lint/checks/TapjackingDetectorTest.kt
@@ -158,7 +158,7 @@ class TapjackingDetectorTest : LintDetectorTest() {
     }
 
     @Test
-    fun testWhenAttributeIsAlreadyPresent_noWarning() {
+    fun testWhenAttributeIsAlreadyPresentAndTrue_showsNoWarning() {
         lint()
             .files(
                 xml(

--- a/checks/src/test/java/com/example/lint/checks/TapjackingDetectorTest.kt
+++ b/checks/src/test/java/com/example/lint/checks/TapjackingDetectorTest.kt
@@ -156,4 +156,50 @@ class TapjackingDetectorTest : LintDetectorTest() {
                 ).indented()
             ).run().expectClean()
     }
+
+    @Test
+    fun testWhenAttributeIsAlreadyPresent_noWarning() {
+        lint()
+            .files(
+                xml(
+                    "res/xml/button.xml",
+                    """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android">
+                        <CompoundButton
+                            android:id='disable_setting'
+                            android:filterTouchesWhenObscured='true' >
+                        </CompoundButton>
+                    </LinearLayout>
+                    """
+                ).indented()
+            ).run().expectClean()
+    }
+
+    @Test
+    fun testWhenAttributeIsAlreadyPresentAndFalse_showsQuickFix() {
+        lint()
+            .files(
+                xml(
+                    "res/xml/button.xml",
+                    """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android">
+                        <CompoundButton
+                            android:id='disable_setting'
+                            android:filterTouchesWhenObscured='false' >
+                        </CompoundButton>
+                    </LinearLayout>
+                    """
+                ).indented()
+            ).run().expectFixDiffs(
+            """
+                    Fix for res/xml/button.xml line 3: Set filterTouchesWhenObscured="true":
+                    @@ -6 +6
+                    -         android:filterTouchesWhenObscured="false" >
+                    +         android:filterTouchesWhenObscured="true" >
+                    """
+        )
+
+    }
 }


### PR DESCRIPTION
Check in the Tapjacking test whether the attribute is already applied
Add extra tests for the new check
Fix a typo
